### PR TITLE
Include duplicates in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,15 @@ module.exports = ({ env }) => ({
   'strapi-v5-plugin-populate-deep': {
     config: {
       defaultDepth: 3, // Default is 5
+      includeDuplicates: true, // Default is false
     }
   },
 });
 ```
 
 This configuration will set the default depth to 3 levels across all API requests unless specified otherwise in the request itself.
+
+The `includeDuplicates` flag controls wether a shared relation is included multiple times in the response. If items `a` and `b` both have a relation to `c`, then with `includeDuplicates: false` (the default), item `c` would only appear under `b` in the API response.
 
 # Contributions
 

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -6,15 +6,25 @@ module.exports = ({ strapi }) => {
   strapi.db.lifecycles.subscribe((event) => {
     if (event.action === "beforeFindMany" || event.action === "beforeFindOne") {
       const level = event.params?.pLevel;
+      const includeDuplicatesParam = event.params?.includeDuplicates;
 
       const defaultDepth =
         strapi
           .plugin("strapi-v5-plugin-populate-deep")
           ?.config("defaultDepth") || 5;
 
+      const defaultIncludeDuplicates =
+        strapi
+          .plugin("strapi-v5-plugin-populate-deep")
+          ?.config("includeDuplicates") || false;
+
       if (level !== undefined) {
         const depth = level ?? defaultDepth;
-        const modelObject = getFullPopulateObject(event.model.uid, depth, []);
+        const includeDuplicates =
+          includeDuplicatesParam !== undefined
+            ? includeDuplicatesParam !== "false"
+            : defaultIncludeDuplicates;
+        const modelObject = getFullPopulateObject(event.model.uid, depth, [], includeDuplicates);
         event.params.populate = modelObject.populate;
       }
     }

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -9,7 +9,7 @@ const getModelPopulationAttributes = (model) => {
   return model.attributes;
 };
 
-const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
+const getFullPopulateObject = (modelUid, maxDepth = 20, ignore, includeDuplicates) => {
   const skipCreatorFields = strapi
       .plugin("strapi-plugin-populate-deep")
       ?.config("skipCreatorFields");
@@ -28,7 +28,7 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
   for (const [key, value] of Object.entries(
       getModelPopulationAttributes(model)
   )) {
-    if (ignore?.includes(key)) continue;
+    if (!includeDuplicates && ignore?.includes(key)) continue;
     if (value) {
       if (value.type === "component") {
         populate[key] = getFullPopulateObject(value.component, maxDepth - 1);
@@ -42,7 +42,8 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
         const relationPopulate = getFullPopulateObject(
             value.target,
             key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
-            ignore
+          ignore,
+          includeDuplicates
         );
         if (relationPopulate) {
           populate[key] = relationPopulate;


### PR DESCRIPTION
This change allows the API response to have a single item appear multiple times as a relation to other items. Previous functionality only added one copy of each item in the response even if multiple items linked to it.